### PR TITLE
chore: CIのフロントエンドLintジョブ名を変更し、依存関係を削除

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -29,7 +29,7 @@ on:
       - ".github/workflows/frontend-check.yml"
 
 jobs:
-  frontend:
+  frontend-lint:
     name: Frontend Lint & Format Check
     runs-on: ubuntu-latest
 
@@ -63,7 +63,6 @@ jobs:
   frontend-test:
     name: Frontend Tests
     runs-on: ubuntu-latest
-    needs: frontend
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:


### PR DESCRIPTION
  フロントエンドLintチェックのジョブ名をfrontendからfrontend-lintに変更し、テストジョブの依存関係を削除した