### PR TITLE
fix: 学生保護者テーブルのis_primaryカラムのデフォルト値を削除

### DIFF
--- a/backend/migration/V4__202507081056_Create_Student_Guardian_Table.sql
+++ b/backend/migration/V4__202507081056_Create_Student_Guardian_Table.sql
@@ -4,7 +4,7 @@ CREATE TABLE student_guardian
     student_id    INTEGER NOT NULL REFERENCES student (id) ON DELETE CASCADE,
     guardian_id   INTEGER NOT NULL REFERENCES "user" (id) ON DELETE CASCADE,
     guardian_type INTEGER NOT NULL,
-    is_primary    BOOLEAN,
+    is_primary    BOOLEAN NOT NULL,
     created_at    TIMESTAMP NOT NULL,
     updated_at    TIMESTAMP,
     UNIQUE (student_id, guardian_id)

--- a/backend/migration/V4__202507081056_Create_Student_Guardian_Table.sql
+++ b/backend/migration/V4__202507081056_Create_Student_Guardian_Table.sql
@@ -4,7 +4,7 @@ CREATE TABLE student_guardian
     student_id    INTEGER NOT NULL REFERENCES student (id) ON DELETE CASCADE,
     guardian_id   INTEGER NOT NULL REFERENCES "user" (id) ON DELETE CASCADE,
     guardian_type INTEGER NOT NULL,
-    is_primary    BOOLEAN DEFAULT FALSE,
+    is_primary    BOOLEAN,
     created_at    TIMESTAMP NOT NULL,
     updated_at    TIMESTAMP,
     UNIQUE (student_id, guardian_id)


### PR DESCRIPTION
is_primaryカラムのデフォルト値をFALSEから削除し、明示的に値を設定する必要があるように変更