### PR TITLE
chore: コミットメッセージの接頭辞チェックを改善

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# コミットメッセージの１行目に特定の接頭辞が含まれているかチェックするスクリプト
+# 許可されたプレフィックス一覧
+readonly PREFIXES=(feat fix docs style refactor perf test chore ci build)
+readonly PREFIX_REGEX="^($(IFS='|'; echo "${PREFIXES[*]}"):|Merge)"
 readonly MSG=$(head -n 1 "$1")
-readonly PREFIX_REGEX="^((feat|fix|docs|style|refactor|perf|test|chore|ci|build):|Merge)"
 
 if [[ ! $MSG =~ $PREFIX_REGEX ]]; then
-  echo "Error: Commit message must start with 'feat:', 'fix:', 'docs:', 'style:', 'refactor:', 'perf:', 'test:', 'chore:', 'ci:', 'build:' or 'Merge'."
+  echo -n "Error: Commit message must start with one of: "
+  (IFS=', '; echo "'${PREFIXES[*]// /', '}'" or 'Merge'.)
   echo "Your commit message was: $MSG"
   exit 1
 fi


### PR DESCRIPTION
許可された接頭辞を配列で管理し、エラーメッセージをより明確に表示するように修正